### PR TITLE
Make all header strings np.string_. Keys <= 8 chars

### DIFF
--- a/src/hera_catcher_disk_thread.c
+++ b/src/hera_catcher_disk_thread.c
@@ -317,22 +317,22 @@ static void start_file(hdf5_id_t *id, char *template_fname, char *hdf5_fname, ui
     if (dataset_id < 0) {
         hashpipe_error(__FUNCTION__, "Failed to close Header/extra_keywords/obs_id");
     }
-    dataset_id = H5Dopen(id->extra_keywords_gid, "paper_gpu_version", H5P_DEFAULT);
+    dataset_id = H5Dopen(id->extra_keywords_gid, "corr_ver", H5P_DEFAULT);
     if (dataset_id < 0) {
-        hashpipe_error(__FUNCTION__, "Failed to open Header/extra_keywords/paper_gpu_version");
+        hashpipe_error(__FUNCTION__, "Failed to open Header/extra_keywords/corr_ver");
     }
     memtype = H5Tcopy(H5T_C_S1);
     stat = H5Tset_size(memtype, VERSION_BYTES);
     if (stat < 0) {
-        hashpipe_error(__FUNCTION__, "Failed to set size of paper_gpu_version memtype");
+        hashpipe_error(__FUNCTION__, "Failed to set size of corr_ver memtype");
     }
     stat = H5Dwrite(dataset_id, memtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, ver);
     if (stat < 0) {
-        hashpipe_error(__FUNCTION__, "Failed to write Header/extra_keywords/paper_gpu_version");
+        hashpipe_error(__FUNCTION__, "Failed to write Header/extra_keywords/corr_ver");
     }
     stat = H5Dclose(dataset_id);
     if (stat < 0) {
-        hashpipe_error(__FUNCTION__, "Failed to close Header/extra_keywords/paper_gpu_version");
+        hashpipe_error(__FUNCTION__, "Failed to close Header/extra_keywords/corr_ver");
     }
     dataset_id = H5Dopen(id->extra_keywords_gid, "startt", H5P_DEFAULT);
     if (dataset_id < 0) {

--- a/src/scripts/hera_make_hdf5_template.py
+++ b/src/scripts/hera_make_hdf5_template.py
@@ -141,21 +141,21 @@ def create_header(h5, use_cm=False, use_redis=False):
 def add_extra_keywords(obj, cminfo=None, fenginfo=None):
     extras = obj.create_group("extra_keywords")
     if cminfo is not None:
-        extras.create_dataset("cmver", data=cminfo["cm_version"])
-        extras.create_dataset("cminfo", data=pickle.dumps(cminfo))
+        extras.create_dataset("cmver", data=np.string_(cminfo["cm_version"]))
+        extras.create_dataset("cminfo", data=np.string_(pickle.dumps(cminfo)))
     else:
-        extras.create_dataset("cmver", data="generated-without-cminfo")
-        extras.create_dataset("cminfo", data="generated-without-cminfo")
+        extras.create_dataset("cmver", data=np.string_("generated-without-cminfo"))
+        extras.create_dataset("cminfo", data=np.string_("generated-without-cminfo"))
     if fenginfo is not None:    
-        extras.create_dataset("fengine_info", data=pickle.dumps(fenginfo))
+        extras.create_dataset("finfo", data=np.string_(pickle.dumps(fenginfo)))
     else:
-        extras.create_dataset("fengine_info", data="generated-without-redis")
-    extras.create_dataset("st_type", data="???")
+        extras.create_dataset("finfo", data=np.string_("generated-without-redis"))
+    #extras.create_dataset("st_type", data=np.string_("???"))
     extras.create_dataset("duration", dtype="<f8", data=0.0) # filled in by receiver
     extras.create_dataset("obs_id", dtype="<i8", data=0)     # filled in by receiver
     extras.create_dataset("startt", dtype="<f8", data=0.0)   # filled in by receiver
     extras.create_dataset("stopt",  dtype="<f8", data=0.0)   # filled in by receiver
-    extras.create_dataset("paper_gpu_version",  dtype="|S32", data=np.string_("unknown"))# filled in by receiver
+    extras.create_dataset("corr_ver",  dtype="|S32", data=np.string_("unknown"))# filled in by receiver
 
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
"Final" meta data fixes.

-- remove st_type key. 
-- shorten software version keys (to comply with pyuvdata's 8char limit. 
-- make all strings use np.string_ (this may or may not break the cminfo / finfo pickles in Python 3. They still work in python 2)