### PR TITLE
Xeng output ct

### DIFF
--- a/src/hera_catcher_disk_thread.c
+++ b/src/hera_catcher_disk_thread.c
@@ -937,6 +937,7 @@ static void *run(hashpipe_thread_args_t * args)
                 // auto_indices default to -1. Use this test to delete
                 // redis keys for invalid antennas
                 if (auto_indices[a] >= 0) {
+                    //fprintf(stdout, "Reporting autocorrs for ant %d (bl %d) to redis\n", a, auto_indices[a]);
                     for (xeng=0; xeng<N_XENGINES_PER_TIME; xeng++) {
                         for (xchan=0; xchan<N_CHAN_PROCESSED/N_XENGINES_PER_TIME; xchan++) {
                             chan = xeng*N_CHAN_PROCESSED/N_XENGINES_PER_TIME + xchan;
@@ -944,6 +945,7 @@ static void *run(hashpipe_thread_args_t * args)
                             // Don't divide out integration over frequency channels (if any)
                             auto_corr_n[chan] = (float) db_in32[hera_catcher_input_databuf_by_bl_idx32(xeng, auto_indices[a]) + (N_STOKES*2*TIME_DEMUX*xchan)] / acc_len;
                             auto_corr_e[chan] = (float) db_in32[hera_catcher_input_databuf_by_bl_idx32(xeng, auto_indices[a]) + (N_STOKES*2*TIME_DEMUX*xchan) + 2] / acc_len;
+                            fprintf(stdout, "ant %d: chan %d, xeng: %d, xchan: %d, val: %f\n", a, chan, xeng, xchan, auto_corr_n[chan]);
                         }
                     }
                     reply = redisCommand(c, "SET auto:%dn %b", a, auto_corr_n, (size_t) (sizeof(float) * N_CHAN_PROCESSED));

--- a/src/hera_catcher_net_thread.c
+++ b/src/hera_catcher_net_thread.c
@@ -246,14 +246,14 @@ static inline uint64_t process_packet(
     binfo.block_packet_counter[binfo.block_i]++;
 
     // Copy data into buffer
-    dest_p = (uint32_t *)(hera_catcher_input_databuf_p->block[binfo.block_i].data) + (hera_catcher_input_databuf_idx32(time_demux_block, xeng_id / TIME_DEMUX, offset));
+    dest_p = (uint32_t *)(hera_catcher_input_databuf_p->block[binfo.block_i].data) + (hera_catcher_input_databuf_idx32(time_demux_block, (xeng_id % N_XENGINES_PER_TIME), offset));
     payload_p = (uint32_t *)(PKT_UDP_DATA(p_frame) + sizeof(packet_header_t));
     if (hera_catcher_input_databuf_idx32(time_demux_block, xeng_id / TIME_DEMUX, offset) >= 455344128L) {
         fprintf(stderr, "databuf offset outside allowed range!\n");
         fprintf(stderr, "offset is %lu\n", (hera_catcher_input_databuf_idx32(time_demux_block, xeng_id/TIME_DEMUX, offset)));
         fprintf(stderr, "mcnt: %lu, t-demux: %d, offset: %d, xeng: %d\n", mcnt, time_demux_block, offset, xeng_id/TIME_DEMUX);
     }
-    //fprintf(stdout, "mcnt: %lu, t-demux: %d, offset: %d, xeng: %d (%d,%d), payload:%d, block:%d\n", mcnt, time_demux_block, offset, xeng_id, ((int32_t *)payload_p)[0], ((int32_t*)payload_p)[1], payload_len, binfo.block_i);
+    //fprintf(stdout, "mcnt: %lu, t-demux: %d, offset: %d, xeng: %d pointer: %lu\n", mcnt, time_demux_block, offset, xeng_id, hera_catcher_input_databuf_idx32(time_demux_block, (xeng_id % N_XENGINES_PER_TIME), offset));
     //fprintf(stdout, "offset is %lu\n", (hera_catcher_input_databuf_idx32(time_demux_block, xeng_id/TIME_DEMUX, offset)));
     //fprintf(stdout, "offset: %d\n", hera_catcher_input_databuf_idx64(time_demux_block, packet_header_p->xeng_id, packet_header_p->offset));
     

--- a/src/hera_gpu_output_thread.c
+++ b/src/hera_gpu_output_thread.c
@@ -388,12 +388,12 @@ static void *run(hashpipe_thread_args_t * args)
         pktdata_t * p_out = pkt.data;
         clock_gettime(CLOCK_MONOTONIC, &pkt_start);
         // Iterate over blocks of XENG_CHAN_SUM channels. An inner loop will sum these
-        for(casper_chan=0; casper_chan<N_CHAN_PER_X; casper_chan=casper_chan+XENG_CHAN_SUM) {
-          // This used to de-interleave channels.  De-interleaving is no longer
-          // needed, but we choose to continue maintaining the distinction
-          // between casper_chan and gpu_chan.
-          gpu_chan = casper_chan;
-          for(baseline=0; baseline<N_CASPER_COMPLEX_PER_CHAN; baseline++) {
+        for(baseline=0; baseline<N_CASPER_COMPLEX_PER_CHAN; baseline++) {
+          for(casper_chan=0; casper_chan<N_CHAN_PER_X; casper_chan=casper_chan+XENG_CHAN_SUM) {
+            // This used to de-interleave channels.  De-interleaving is no longer
+            // needed, but we choose to continue maintaining the distinction
+            // between casper_chan and gpu_chan.
+            gpu_chan = casper_chan;
             off_t idx_regtile = idx_map[baseline];
             for(sum_chan=0; sum_chan<XENG_CHAN_SUM; sum_chan++) {
               if (sum_chan == 0) {

--- a/src/paper_databuf.h
+++ b/src/paper_databuf.h
@@ -36,6 +36,8 @@
 #define N_BYTES_PER_BLOCK            (N_TIME_PER_BLOCK * N_CHAN_PER_X * N_INPUTS)
 #define N_PACKETS_PER_BLOCK          (N_BYTES_PER_BLOCK / N_BYTES_PER_PACKET)
 #define N_PACKETS_PER_BLOCK_PER_F    (N_PACKETS_PER_BLOCK * N_INPUTS_PER_PACKET / 2 / N_FENGINES)
+// Number of X-engines per time slice. E.g. for HERA: 8.
+#define N_XENGINES_PER_TIME (N_CHAN_TOTAL / N_CHAN_PER_X)
 
 // Validate packet dimensions
 #if    N_BYTES_PER_PACKET != (N_TIME_PER_PACKET*N_CHAN_PER_PACKET*N_INPUTS_PER_PACKET)
@@ -287,8 +289,12 @@ typedef struct hera_catcher_input_databuf {
   hera_catcher_input_block_t block[CATCHER_N_BLOCKS];
 } hera_catcher_input_databuf_t;
 
-#define hera_catcher_input_databuf_idx32(x, o) \
-  (2L*(VIS_MATRIX_ENTRIES_PER_CHAN * (N_CHAN_PER_X/XENG_CHAN_SUM)*x) + (o>>2))
+// Catcher input buffer has dimensions:
+// n-xengines x n-baselines x nchans-per-x x time-demux x stokes x real/imag
+#define hera_catcher_input_databuf_idx32(t, x, o) \
+  (2L*TIME_DEMUX*(VIS_MATRIX_ENTRIES_PER_CHAN * (N_CHAN_PER_X/XENG_CHAN_SUM)*(x)) + (TIME_DEMUX*((o)>>2)) + (2*N_STOKES*(t)))
+#define hera_catcher_input_databuf_by_bl_idx32(x, b) \
+  (2L*TIME_DEMUX*(N_CHAN_PER_X/XENG_CHAN_SUM)*((VIS_MATRIX_ENTRIES_PER_CHAN * (x)) + (b)))
 
 /*
  * INPUT BUFFER FUNCTIONS

--- a/src/paper_databuf.h
+++ b/src/paper_databuf.h
@@ -36,7 +36,7 @@
 #define N_BYTES_PER_BLOCK            (N_TIME_PER_BLOCK * N_CHAN_PER_X * N_INPUTS)
 #define N_PACKETS_PER_BLOCK          (N_BYTES_PER_BLOCK / N_BYTES_PER_PACKET)
 #define N_PACKETS_PER_BLOCK_PER_F    (N_PACKETS_PER_BLOCK * N_INPUTS_PER_PACKET / 2 / N_FENGINES)
-// Number of X-engines per time slice. E.g. for HERA: 8.
+// Number of X-engines per time slice. E.g. for HERA: 16.
 #define N_XENGINES_PER_TIME (N_CHAN_TOTAL / N_CHAN_PER_X)
 
 // Validate packet dimensions
@@ -294,7 +294,7 @@ typedef struct hera_catcher_input_databuf {
 #define hera_catcher_input_databuf_idx32(t, x, o) \
   (2L*TIME_DEMUX*(VIS_MATRIX_ENTRIES_PER_CHAN * (N_CHAN_PER_X/XENG_CHAN_SUM)*(x)) + (TIME_DEMUX*((o)>>2)) + (2*N_STOKES*(t)))
 #define hera_catcher_input_databuf_by_bl_idx32(x, b) \
-  (2L*TIME_DEMUX*(N_CHAN_PER_X/XENG_CHAN_SUM)*((VIS_MATRIX_ENTRIES_PER_CHAN * (x)) + (b)))
+  (2L*TIME_DEMUX*(N_CHAN_PER_X/XENG_CHAN_SUM)*((VIS_MATRIX_ENTRIES_PER_CHAN * (x)) + (N_STOKES*b)))
 
 /*
  * INPUT BUFFER FUNCTIONS

--- a/src/paper_gpu_thread.c
+++ b/src/paper_gpu_thread.c
@@ -145,7 +145,7 @@ static void *run(hashpipe_thread_args_t * args, int doCPU)
               hashpipe_status_unlock_safe(&st);
               // Compute last mcount
               last_mcount = start_mcount + TIME_DEMUX*(int_count-N_TIME_PER_BLOCK);// * N_SUB_BLOCKS_PER_INPUT_BLOCK;
-              middle_mcount = (last_mcount - start_mcount + N_TIME_PER_BLOCK) >> 2;
+              middle_mcount = (last_mcount + start_mcount + TIME_DEMUX*N_TIME_PER_BLOCK) >> 1;
               fprintf(stdout, "Accumulating %d spectra to mcount: %lu\n", int_count, last_mcount);
             // Else (missed starting mcount)
             } else {

--- a/src/tests/check_fluff_output_databuf.py
+++ b/src/tests/check_fluff_output_databuf.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+
+import sys
+import numpy as np
+
+NTIMES = 2048
+NTIME_FAST = 4
+NCHAN = 384
+NANT  = 192
+NPOL  = 2
+NCPLX = 2
+
+
+with open(sys.argv[1], 'r') as fh:
+    raw = fh.read()
+
+x = np.fromstring(raw, dtype='b')
+
+x = x.reshape(NTIMES/NTIME_FAST, NCHAN, NANT, NPOL, NCPLX, NTIME_FAST)
+
+tvg = np.zeros([NANT, NPOL, NCHAN, NCPLX])
+
+# Generate a test vector valid for all times
+for a in range(NANT):
+    for p in range(NPOL):
+        chan_ramp = (np.arange(NCHAN) + 2*(a%3) + p) % 256
+        chan_ramp_r = chan_ramp >> 4
+        chan_ramp_i = chan_ramp & 0xf
+        chan_ramp_r[chan_ramp_r > 7] -= 16
+        chan_ramp_i[chan_ramp_i > 7] -= 16
+        tvg[a,p,:,1] = chan_ramp_r
+        tvg[a,p,:,0] = chan_ramp_i
+
+#print x[0,:,0,0,0,0]
+#print tvg[0,0,:,0]
+#exit()
+
+for a in range(12):
+    ok = True
+    for p in range(NPOL):
+        for t in range(NTIMES/NTIME_FAST):
+            for t_fast in range(NTIME_FAST):
+                for cplx in range(NCPLX):
+                    ok = ok and np.all(tvg[a, p, :, cplx] == x[t, :, a, p, cplx, t_fast])
+    print "Antenna %d: OK?:" % a, ok
+    #print tvg[a,0,:,:], x[0,:,a,0,:,0]

--- a/src/tests/check_gpu_output_databuf.py
+++ b/src/tests/check_gpu_output_databuf.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+
+import sys
+import numpy as np
+
+NTIMES = 2048
+NTIME_FAST = 4
+NCHAN = 384
+NANT  = 192
+NPOL  = 2
+NCPLX = 2
+
+
+with open(sys.argv[1], 'r') as fh:
+    raw = fh.read()
+
+x = np.fromstring(raw, dtype=np.int32)
+
+print "All values equal to 0?:", np.all(x == 0)
+print "All values divisible by 2048?:", np.all((x % 2048) == 0)
+print "All values divisible by 262144?:", np.all((x % 262144) == 0)

--- a/src/tests/check_net_output_databuf.py
+++ b/src/tests/check_net_output_databuf.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python
+
+import sys
+import numpy as np
+
+NTIMES = 2048
+NTIME_PER_PKT = 2
+NCHAN_PER_PKT = 384
+NANT_PER_PKT = 3
+NANT_TOTAL = 192
+NPOL_PER_PKT = 2
+
+
+with open(sys.argv[1], 'r') as fh:
+    raw = fh.read()
+
+x = np.fromstring(raw, dtype='B')
+
+x = x.reshape(NTIMES/NTIME_PER_PKT, NANT_TOTAL, NCHAN_PER_PKT, NTIME_PER_PKT, NPOL_PER_PKT)
+
+tvg = np.zeros([NTIMES/NTIME_PER_PKT, NANT_TOTAL, NCHAN_PER_PKT, NTIME_PER_PKT, NPOL_PER_PKT])
+
+ramp = np.arange(384) % 256
+for t in range(NTIMES/NTIME_PER_PKT):
+    for t_pkt in range(NTIME_PER_PKT):
+        for a in range(NANT_TOTAL):
+            for p in range(NPOL_PER_PKT):
+                tvg[t, a, :, t_pkt, p] = (np.arange(384) + 2*(a%3) + p) % 256
+
+for a in range(NANT_TOTAL):
+    print "Antenna %d: OK?:" % a,
+    print np.all(tvg[:,a,:,:,:] == x[:,a,:,:,:])


### PR DESCRIPTION
Move data transpose into X-engine boxes (so that it is distributed over more nodes).

Simplify data reordering in catcher, and update sum/diff calcs to use AVX instructions.
Throughput now ~1GB/s (over 24 hr run the lowest reported block write speed was 560 MB/s)