### PR TITLE
Change which environment calls M&C script

### DIFF
--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -626,7 +626,7 @@ static void add_mc_obs(char *fname)
   int err;
   fprintf(stdout, "Adding observation %s to M&C\n", fname);
   // Launch (hard-coded) python script in the background and pass in filename
-  sprintf(cmd, "/home/hera/hera-venv/bin/mc_add_observation.py %s", fname);
+  sprintf(cmd, "/home/hera/anaconda3/envs/hera3/bin/mc_add_observation.py %s", fname);
   if (fork() == 0) {
     err = system(cmd);
     if (err != 0) {


### PR DESCRIPTION
This environment for M&C is python3, and hopefully doesn't have the same IERS problem as the old one.