### PR TITLE
Add x_orientation to output files

### DIFF
--- a/src/scripts/hera_make_hdf5_template_bda.py
+++ b/src/scripts/hera_make_hdf5_template_bda.py
@@ -213,6 +213,7 @@ def create_header(h5, config, use_cm=False, use_redis=False):
     header.create_dataset("spw_array",      dtype="<i8", data=[0])
     header.create_dataset("telescope_name", data=np.string_("HERA"))
     header.create_dataset("vis_units",  data=np.string_("UNCALIB"))
+    header.create_dataset("x_orientation", data=np.string_("NORTH"))
     if use_cm:
         # convert lat and lon from degrees -> radians
         lat = cminfo['cofa_lat'] * np.pi / 180.


### PR DESCRIPTION
With transitioning to the BDA branch, the `x_orientation` got lost in the shuffle. This PR adds it back.