### PR TITLE
Allow multiple IBV UDP source ports

### DIFF
--- a/src/paper_databuf.h
+++ b/src/paper_databuf.h
@@ -12,6 +12,11 @@
 //#define N_FENGINES   192 # isn't this always the same as the number of antennas?
 #define N_CHAN_PER_F N_CHAN_TOTAL
 
+// Number of F-engine source ports used.
+// Using more ports means more IBV receive buffers,
+// which potentially increases performance
+#define N_SRC_PORTS 8
+
 // Number of separate X-engines which deal with
 // alternate time chunks
 #define TIME_DEMUX 2

--- a/src/scripts/xtor_up.py
+++ b/src/scripts/xtor_up.py
@@ -117,7 +117,7 @@ else:
          key = 'hashpipe://%s/%d/set' % (host, i)
          r.publish(key, 'TIMEIDX=%d' % (hn//nhosts_per_timeslice))
 
-time.sleep(2)
+time.sleep(10)
 
 # Let the network threads begin processing
 for hn, host in enumerate(hosts):


### PR DESCRIPTION
This commit instantiates multiple IBV rules for different
UDP source ports. This effectively increases the size of the
IBV receive buffers, providing performance increases.

This commit was tested in the lab with 360 antennas (2 x 33.75 Gb/s throughput;
2 x 34.1 Gb/s including app header (but not UDP/IP/Eth header).

Over 15 hours, it lost 102 packets (all in one burst from one of the
two parallel pipelines). This was tested with the GPU and output threads
active. (17.18 seconds integration using BDA configuration)

Possibly performance could be further improved by using >8 source ports,
but this is not possible with the current 360 antenna lab emulator,
which only uses 8 SNAP boards.