### PR TITLE
Make repo python3-only

### DIFF
--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -500,7 +500,7 @@ static double compute_jd_from_mcnt(uint64_t mcnt, uint64_t sync_time_ms, double 
  * Write N_BL_PER_WRITE bcnts to the dataset, at the right offset
  */
 static void write_baseline_index(hdf5_id_t *id, hsize_t bcnt, hsize_t nblts, hid_t mem_space, 
-                                 uint64_t *visdata_buf, hbool_t *flags, uint32_t *nsamples)
+                                 uint64_t *visdata_buf, hbool_t *flags, float *nsamples)
 {
     hsize_t start[N_DATA_DIMS] = {bcnt, 0, 0, 0};
     hsize_t count[N_DATA_DIMS] = {nblts, 1, N_CHAN_PROCESSED, N_STOKES};
@@ -776,10 +776,10 @@ static void *run(hashpipe_thread_args_t * args)
 
     // Allocate an array of bools for flags and n_samples
     hbool_t *flags     = (hbool_t *) malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
-    uint32_t *nsamples = (uint32_t *)malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(uint32_t));
+    float *nsamples = (float *)malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
 
     memset(flags,    0, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
-    memset(nsamples, 1, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(uint32_t));
+    memset(nsamples, 1, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
 
     // Define memory space of a block
     hsize_t dims[N_DATA_DIMS] = {N_BL_PER_WRITE, 1, N_CHAN_PROCESSED, N_STOKES};

--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -626,7 +626,7 @@ static void add_mc_obs(char *fname)
   int err;
   fprintf(stdout, "Adding observation %s to M&C\n", fname);
   // Launch (hard-coded) python script in the background and pass in filename
-  sprintf(cmd, "/home/hera/hera-venv/bin/mc_add_observation.py %s", fname);
+  sprintf(cmd, "/home/hera/hera-venv/envs/hera/bin/mc_add_observation.py %s", fname);
   if (fork() == 0) {
     err = system(cmd);
     if (err != 0) {

--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -626,7 +626,7 @@ static void add_mc_obs(char *fname)
   int err;
   fprintf(stdout, "Adding observation %s to M&C\n", fname);
   // Launch (hard-coded) python script in the background and pass in filename
-  sprintf(cmd, "/home/hera/anaconda3/envs/hera3/bin/mc_add_observation.py %s", fname);
+  sprintf(cmd, "/home/hera/hera-venv/bin/mc_add_observation.py %s", fname);
   if (fork() == 0) {
     err = system(cmd);
     if (err != 0) {

--- a/src/scripts/catcher.py
+++ b/src/scripts/catcher.py
@@ -2,7 +2,7 @@ import socket
 import numpy as np
 import struct
 import time
-import cPickle as pickle
+import pickle as pickle
 
 
 NANTS = 192
@@ -14,14 +14,14 @@ NWORDS_PER_XENG = NWORDS / NXENG
 PAYLOAD_LEN = 4096
 BYTES_PER_PACKET = PAYLOAD_LEN + 16
 max_offset = NWORDS*8 / NXENG - PAYLOAD_LEN
-print "Max offset:", max_offset
+print("Max offset:", max_offset)
 
 NPACKETS = NWORDS * 8 / PAYLOAD_LEN
-print "Expecting %d packets" % NPACKETS
+print("Expecting %d packets" % NPACKETS)
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 800000000)
-print sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+print(sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
 
 sock.bind(("10.80.40.251", 10000))
 
@@ -42,10 +42,10 @@ while True:
         this_window = timestamp
     if (not wait) or (offset == 0):
         if  (timestamp != this_window):
-            print timestamp, this_window
+            print(timestamp, this_window)
             stop = time.time()
-            print "%d packets received in %.2f seconds" % (n, stop - start)
-            print "Missing %d packets" % (NPACKETS - n)
+            print("%d packets received in %.2f seconds" % (n, stop - start))
+            print("Missing %d packets" % (NPACKETS - n))
             n = 0
             start = stop
             break
@@ -58,7 +58,7 @@ while True:
         dout[xeng_id, offset>>2:(offset+PAYLOAD_LEN)>>2] = np.fromstring(data[16:], dtype='>i')
 
 
-print "Dumping packet to disk"
+print("Dumping packet to disk")
 with open("/tmp/packet.bin", "w") as fh:
     fh.write(dout.flatten().tostring()) #This is native (probably little) endian!!
 

--- a/src/scripts/check_catcher_dump.py
+++ b/src/scripts/check_catcher_dump.py
@@ -28,10 +28,10 @@ with open("/tmp/packet.bin", "r") as fh:
 bl_order = get_bl_order(NANTS)
 x = x.reshape(2, NCHANS, NBL, 4, 2)
 
-print np.all(x==0)
+print(np.all(x==0))
 
 for bn, bl in enumerate(bl_order):
     r = x[0,:,bn,0,0]
     i = x[0,:,bn,0,1]
     if not (np.all(r==0) and np.all(i==0)):
-        print bl[0], bl[1], r, i
+        print(bl[0], bl[1], r, i)

--- a/src/scripts/gen_fake_corr_output.py
+++ b/src/scripts/gen_fake_corr_output.py
@@ -20,9 +20,9 @@ n_bytes = TIME_DEMUX * NCHANS * n_bls * 2 * 4 # real/imag, bytes-per-word
 n_pkts = (n_bytes / BYTES_PER_PACKET)
 n_pkts_per_x = n_pkts / NX
 
-print "MBytes per dump: %.2f" % (n_bytes / 1e6)
-print "Packets per dump: %.4f" % (n_bytes / float(BYTES_PER_PACKET))
-print "Packets per Xeng: %.4f" % n_pkts_per_x
+print("MBytes per dump: %.2f" % (n_bytes / 1e6))
+print("Packets per dump: %.4f" % (n_bytes / float(BYTES_PER_PACKET)))
+print("Packets per Xeng: %.4f" % n_pkts_per_x)
 
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
@@ -48,5 +48,5 @@ while(True):
     if wait_time > 0:
         time.sleep(wait_time)
     total_time = time.time() - start
-    print "dump sent (MCNT: %d) in %.2fs at %.2f Gb/s" % (mcnt, total_time, n_bytes*8 / elapsed / 1e9)
+    print("dump sent (MCNT: %d) in %.2fs at %.2f Gb/s" % (mcnt, total_time, n_bytes*8 / elapsed / 1e9))
 

--- a/src/scripts/hera_catcher_stop_data.py
+++ b/src/scripts/hera_catcher_stop_data.py
@@ -22,5 +22,5 @@ catcher_dict = {
 }
   
 pubchan = 'hashpipe://%s/%d/set' % (args.host, 0)
-for key, val in catcher_dict.iteritems():
+for key, val in catcher_dict.items():
    r.publish(pubchan, '%s=%s' % (key, val))

--- a/src/scripts/hera_catcher_take_data.py
+++ b/src/scripts/hera_catcher_take_data.py
@@ -53,7 +53,7 @@ catcher_dict = {
 }
   
 pubchan = 'hashpipe://%s/%d/set' % (args.host, 0)
-for key, val in catcher_dict.iteritems():
+for key, val in catcher_dict.items():
    r.publish(pubchan, '%s=%s' % (key, val))
 
 # Only trigger after the other parameters have had ample time to write

--- a/src/scripts/hera_catcher_take_data.py
+++ b/src/scripts/hera_catcher_take_data.py
@@ -6,7 +6,8 @@ import argparse
 import subprocess
 
 python_source_cmd = ['source', '~/hera-venv/bin/activate']
-template_cmd = ['hera_make_hdf5_template_bda.py']
+template_cmd_bda = ['hera_make_hdf5_template_bda.py']
+template_cmd = ['hera_make_hdf5_template.py']
 
 def run_on_hosts(hosts, cmd, user=None, wait=True):
     if isinstance(cmd, str):
@@ -28,6 +29,8 @@ parser.add_argument('host', type=str, help='Host on which to capture data')
 parser.add_argument('-r', dest='redishost', type=str, default='redishost', help='Host serving redis database')
 parser.add_argument('-n', dest='nfiles', type=int, default=10, help='Number of files of data to capture')
 parser.add_argument('-m', dest='msperfile', type=int, default=60000, help='Number of ms of data per file')
+parser.add_argument('--nobda', dest='nobda', action='store_true', default=False,
+                    help='Use the baseline dependent averaging version')
 parser.add_argument('--tag', dest='tag', type=str, default='none', help='A descriptive tag to go into data files')
 parser.add_argument('-t', dest='hdf5template', type=str, default='/tmp/template.h5', help='Place to put HDF5 header template file')
 
@@ -39,7 +42,10 @@ if len(args.tag) > 127:
   raise ValueError("Tag argument must be <127 characters!")
 
 # Generate the meta-data template
-run_on_hosts([args.host], python_source_cmd + [';'] + template_cmd + ['-c', '-r', args.hdf5template], wait=True)
+if not args.nobda:
+    run_on_hosts([args.host], python_source_cmd + [';'] + template_cmd_bda + ['-c', '-r', args.hdf5template], wait=True)
+else:
+   run_on_hosts([args.host], python_source_cmd + [';'] + template_cmd + ['-c', '-r', args.hdf5template], wait=True)
 
 
 #Configure runtime parameters

--- a/src/scripts/hera_catcher_take_data.py
+++ b/src/scripts/hera_catcher_take_data.py
@@ -33,7 +33,7 @@ parser.add_argument('-t', dest='hdf5template', type=str, default='/tmp/template.
 
 args = parser.parse_args()
 
-r = redis.Redis(args.redishost)
+r = redis.Redis(args.redishost, decode_responses=True)
 
 if len(args.tag) > 127:
   raise ValueError("Tag argument must be <127 characters!")

--- a/src/scripts/hera_catcher_up.py
+++ b/src/scripts/hera_catcher_up.py
@@ -47,7 +47,7 @@ args = parser.parse_args()
 # Environment sourcing command required to run remote python jobs
 python_source_cmd = ["source", os.path.join(args.pypath, "bin/activate"), ";"]
 
-r = redis.Redis(args.redishost)
+r = redis.Redis(args.redishost, decode_responses=True)
 
 # Run performance tweaking script
 if args.runtweak:

--- a/src/scripts/hera_catcher_up.py
+++ b/src/scripts/hera_catcher_up.py
@@ -74,7 +74,7 @@ time.sleep(15)
 # NOTE: This has to come before template generation!
 # Generate the BDA config file and upload to redis
 if not args.nobda:
-    print 'Create configuration file'
+    print('Create configuration file')
     run_on_hosts([args.host], python_source_cmd + bda_config_cmd + ['-c','-r', '/tmp/bdaconfig.txt'], wait=True)
     os.system('scp "%s:%s" "%s" ' % ('hera-sn1', '/tmp/bdaconfig.txt','/tmp/bdaconfig.txt') )
     
@@ -98,7 +98,7 @@ catcher_dict = {
 # Reset various statistics counters
 
 pubchan = 'hashpipe://%s/%d/set' % (args.host, 0)
-for key, val in catcher_dict.iteritems():
+for key, val in catcher_dict.items():
    r.publish(pubchan, '%s=%s' % (key, val))
 for v in ['NETWAT', 'NETREC', 'NETPRC']:
     r.publish(pubchan, '%sMN=99999' % (v))
@@ -122,7 +122,7 @@ if not args.nobda:
          Nants += 1
    
    for i in range(4):
-       print (i, len(baselines[i]))
+       print((i, len(baselines[i])))
        r.publish(pubchan, 'NBL%dSEC=%d'  % (2**(i+1), len(baselines[i])))
    r.publish(pubchan, 'BDANANT=%d' % Nants)
    

--- a/src/scripts/hera_check_catcher_bda.py
+++ b/src/scripts/hera_check_catcher_bda.py
@@ -105,30 +105,30 @@ while True:
         packets += 1
         t,b,o,a0,a1,x,l,data = decode_packet(pkt)
         if args.verbose and args.snap:
-           print "{0:4d} {1:3d} {2:4d} {3:1d} {4:3d} {5:3d} {6:2d}".format(t, b//N_bl_per_block, b%N_bl_per_block, o, a0, a1, x), data[:8]//INTSPEC
+           print("{0:4d} {1:3d} {2:4d} {3:1d} {4:3d} {5:3d} {6:2d}".format(t, b//N_bl_per_block, b%N_bl_per_block, o, a0, a1, x), data[:8]//INTSPEC)
         elif args.verbose:
-           print "{0:4d} {1:3d} {2:4d} {3:1d} {4:3d} {5:3d} {6:2d}".format(t, b//N_bl_per_block, b%N_bl_per_block, o, a0, a1, x), data[:8]
+           print("{0:4d} {1:3d} {2:4d} {3:1d} {4:3d} {5:3d} {6:2d}".format(t, b//N_bl_per_block, b%N_bl_per_block, o, a0, a1, x), data[:8])
 
         if args.check:
            if (a0 > N_ANTS_DATA or a1 > N_ANTS_DATA): 
-              print "Error! Received wrong antenna!"
+              print("Error! Received wrong antenna!")
            if args.snap:
               # Test data from snap
               if (a0 == 0) and (a1 == 1):
                  tspec = gen_tvg_pol(a0*2)*np.conj(gen_tvg_pol(a1*2))
                  data = data.reshape(128,4,2)//INTSPEC
                  if (a0 == a1):
-                    print a0, a1, o, np.all(tspec.real[o*128:(o+1)*128] == data[:,0,0])
+                    print(a0, a1, o, np.all(tspec.real[o*128:(o+1)*128] == data[:,0,0]))
                  else:
-                    print a0, a1, o, np.all(tspec.real[o*128:(o+1)*128] == data[:,0,0]//4)
+                    print(a0, a1, o, np.all(tspec.real[o*128:(o+1)*128] == data[:,0,0]//4))
        
            else:
-              n = [y for y,v in int_bin['baselines'].items() if (a0,a1) in v][0]
+              n = [y for y,v in list(int_bin['baselines'].items()) if (a0,a1) in v][0]
               if not (np.all(data == int_bin['data'][n][o*1024:(o+1)*1024])):
-                 print "Error!", int_bin['data'][n][:32:8], o, n, data[:32:8]
+                 print("Error!", int_bin['data'][n][:32:8], o, n, data[:32:8])
                  errors += 1
     except(KeyboardInterrupt):
        print("")
-       print("Total number of packets captured: %d"%packets)
-       print("Total number of errors: %d"%errors)
+       print(("Total number of packets captured: %d"%packets))
+       print(("Total number of errors: %d"%errors))
        break

--- a/src/scripts/hera_create_bda_config.py
+++ b/src/scripts/hera_create_bda_config.py
@@ -25,7 +25,8 @@ def get_hera_to_corr_ants(r, ants=None):
     corresponding correlator numbers from the
     redis database, using a redis.Redis instance (r)
     """
-    ant_to_snap = json.loads(r.hgetall("corr:map")['ant_to_snap'])
+    # dictionary keys are bytes, not strings
+    ant_to_snap = json.loads(r.hgetall("corr:map")[b'ant_to_snap'])
     corr_nums = []
     if ants is None:
         ants = [int(a) for a in ant_to_snap.keys()]
@@ -43,7 +44,8 @@ def create_bda_config(n_ants_data, use_cm=False, use_redis=False):
     # This does not account for BDA!!!
     if use_cm:
         cminfo = get_cm_info()
-        ants = cminfo['antenna_numbers']
+        # dictionary keys are bytes, not strings
+        ants = cminfo[b'antenna_numbers']
 
     if use_redis:
        r = redis.Redis('redishost')

--- a/src/scripts/hera_create_bda_config.py
+++ b/src/scripts/hera_create_bda_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, division, absolute_import
+
 import h5py
 import sys
 import json

--- a/src/scripts/hera_create_bda_config.py
+++ b/src/scripts/hera_create_bda_config.py
@@ -26,7 +26,7 @@ def get_hera_to_corr_ants(r, ants=None):
     redis database, using a redis.Redis instance (r)
     """
     # dictionary keys are bytes, not strings
-    ant_to_snap = json.loads(r.hgetall("corr:map")[b'ant_to_snap'])
+    ant_to_snap = json.loads(r.hgetall("corr:map")['ant_to_snap'])
     corr_nums = []
     if ants is None:
         ants = [int(a) for a in ant_to_snap.keys()]
@@ -45,10 +45,10 @@ def create_bda_config(n_ants_data, use_cm=False, use_redis=False):
     if use_cm:
         cminfo = get_cm_info()
         # dictionary keys are bytes, not strings
-        ants = cminfo[b'antenna_numbers']
+        ants = cminfo['antenna_numbers']
 
     if use_redis:
-       r = redis.Redis('redishost')
+       r = redis.Redis('redishost', decode_responses=True)
        corr_ant_nums = get_hera_to_corr_ants(r, ants)
 
     else:

--- a/src/scripts/hera_ctl.py
+++ b/src/scripts/hera_ctl.py
@@ -39,7 +39,7 @@ parser.add_argument('-S', dest='slice_by_xbox', action="store_true",
 args = parser.parse_args()
 
 if args.action not in ['start', 'stop']:
-    print 'Available actions are "start" and "stop"'
+    print('Available actions are "start" and "stop"')
     exit
 
 # Make status keys for the various X-engine instances which identify their redis entries
@@ -66,16 +66,16 @@ if args.action == 'start':
     trig_time = trig_mcnt / mcnts_per_second() + mcnt_origin
 
     #print 'Current MCNTs are:', gpumcnts
-    print 'Sync time is %s' % time.ctime(mcnt_origin)
-    print 'MCNTs per second: %.1f' % mcnts_per_second()
-    print 'Requested start time: %s' % time.ctime(args.starttime)
-    print 'Trigger MCNT: %d' % trig_mcnt
-    print 'Trigger time is %.1f seconds in the future (%s)' % (trig_time - time.time(), time.ctime(trig_time))
+    print('Sync time is %s' % time.ctime(mcnt_origin))
+    print('MCNTs per second: %.1f' % mcnts_per_second())
+    print('Requested start time: %s' % time.ctime(args.starttime))
+    print('Trigger MCNT: %d' % trig_mcnt)
+    print('Trigger time is %.1f seconds in the future (%s)' % (trig_time - time.time(), time.ctime(trig_time)))
 
     # round acc_len
     acclen = int(args.acclen / MCNT_XGPU_BLOCK_SIZE) * MCNT_XGPU_BLOCK_SIZE
-    print 'Requested accumulation length: %d' % args.acclen
-    print 'Actual accumulation length: %d' % acclen
+    print('Requested accumulation length: %d' % args.acclen)
+    print('Actual accumulation length: %d' % acclen)
 
     # Use the hashpipe publish channel to update keys in all status buffers.
     # See the docstring at https://github.com/david-macmahon/rb-hashpipe/blob/master/bin/hashpipe_redis_gateway.rb

--- a/src/scripts/hera_fake_bda_output.py
+++ b/src/scripts/hera_fake_bda_output.py
@@ -67,8 +67,8 @@ for i,t in enumerate(bdaconfig[:,2]):
     if (n==4): n = 3
     int_bin['baselines'][n].append((bdaconfig[i,0], bdaconfig[i,1]))
 
-for b in int_bin['baselines'].keys():
-    print b,len(int_bin['baselines'][b])
+for b in list(int_bin['baselines'].keys()):
+    print(b,len(int_bin['baselines'][b]))
 
 bcnt = 0; mcnt = 0; ctr = 0;
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -80,7 +80,7 @@ while True:
    for ns in np.logspace(1, Nbins, num=Nbins, base=2, dtype=np.int):
        if (ctr%ns == 0):
            nb = int(np.log2(ns)) - 1
-           print 'Sending: %d \tBaselines: %d \tBcnt: %d' % (ns, len(int_bin['baselines'][nb]), bcnt)
+           print('Sending: %d \tBaselines: %d \tBcnt: %d' % (ns, len(int_bin['baselines'][nb]), bcnt))
            for (a0,a1) in int_bin['baselines'][nb]:
                for xeng_id in range(Nx*Nt):
                    b = mcnt+((xeng_id//Nx)*2)

--- a/src/scripts/hera_make_hdf5_template.py
+++ b/src/scripts/hera_make_hdf5_template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, division, absolute_import
+
 import h5py
 import json
 import logging
@@ -8,9 +8,7 @@ import numpy as np
 import time
 import copy
 import redis
-from hera_corr_f import helpers
-
-logger = helpers.add_default_log_handlers(logging.getLogger(__file__))
+import warnings
 
 def get_corr_to_hera_map(r, nants_data=192, nants=352):
     """
@@ -25,18 +23,18 @@ def get_corr_to_hera_map(r, nants_data=192, nants=352):
     # of the for {<ant> :{<pol>: {'host':SNAPHOSTNAME, 'channel':INTEGER}}}
     ant_to_snap = json.loads(r.hgetall("corr:map")['ant_to_snap'])
     #host_to_index = r.hgetall("corr:snap_ants")
-    for ant, pol in ant_to_snap.iteritems():
+    for ant, pol in ant_to_snap.items():
         hera_ant_number = int(ant)
         host = pol["n"]["host"]
         chan = pol["n"]["channel"] # runs 0-5
         snap_ant_chans = r.hget("corr:snap_ants", host)
         if snap_ant_chans is None:
-            logger.warning("Couldn't find antenna indices for %s" % host)
+            warnings.warn("Couldn't find antenna indices for %s" % host)
             continue
         corr_ant_number = json.loads(snap_ant_chans)[chan//2] #Indexes from 0-3 (ignores pol)
         print(corr_ant_number)
         out_map[corr_ant_number] = hera_ant_number
-        logger.info("HERA antenna %d maps to correlator input %d" % (hera_ant_number, corr_ant_number))
+        print("HERA antenna %d maps to correlator input %d" % (hera_ant_number, corr_ant_number))
 
     return out_map
 
@@ -220,7 +218,7 @@ def create_header(h5, use_cm=False, use_redis=False):
     else:
         header.create_dataset("altitude",    dtype="<f8", data=0.0)
         header.create_dataset("antenna_names",     dtype="|S5", shape=(NANTS,), data=["NONE"]*NANTS)
-        header.create_dataset("antenna_numbers",   dtype="<i8", shape=(NANTS,), data=range(NANTS))
+        header.create_dataset("antenna_numbers",   dtype="<i8", shape=(NANTS,), data=list(range(NANTS)))
         header.create_dataset("antenna_positions",   dtype="<f8", shape=(NANTS,3), data=np.zeros([NANTS,3]))
         header.create_dataset("antenna_positions_enu",   dtype="<f8", shape=(NANTS,3), data=np.zeros([NANTS,3]))
         header.create_dataset("latitude",    dtype="<f8", data=0.0)
@@ -242,7 +240,7 @@ def add_extra_keywords(obj, cminfo=None, fenginfo=None):
         extras.create_dataset("cmver", data=np.string_(cminfo["cm_version"]))
         # Convert any numpy arrays to lists so they can be JSON encoded
         cminfo_copy = copy.deepcopy(cminfo)
-        for key in cminfo_copy.keys():
+        for key in list(cminfo_copy.keys()):
             if isinstance(cminfo_copy[key], np.ndarray):
                 cminfo_copy[key] = cminfo_copy[key].tolist()
         extras.create_dataset("cminfo", data=np.string_(json.dumps(cminfo_copy)))

--- a/src/scripts/hera_make_hdf5_template.py
+++ b/src/scripts/hera_make_hdf5_template.py
@@ -8,7 +8,9 @@ import numpy as np
 import time
 import copy
 import redis
-import warnings
+from hera_corr_cm.handlers import add_default_log_handlers
+
+logger = add_default_log_handlers(logging.getLogger(__file__))
 
 def get_corr_to_hera_map(r, nants_data=192, nants=352):
     """
@@ -29,7 +31,7 @@ def get_corr_to_hera_map(r, nants_data=192, nants=352):
         chan = pol["n"]["channel"] # runs 0-5
         snap_ant_chans = r.hget("corr:snap_ants", host)
         if snap_ant_chans is None:
-            warnings.warn("Couldn't find antenna indices for %s" % host)
+            logger.warning("Couldn't find antenna indices for %s" % host)
             continue
         corr_ant_number = json.loads(snap_ant_chans)[chan//2] #Indexes from 0-3 (ignores pol)
         print(corr_ant_number)

--- a/src/scripts/hera_make_hdf5_template_bda.py
+++ b/src/scripts/hera_make_hdf5_template_bda.py
@@ -74,7 +74,7 @@ def get_cm_info():
 
 def get_antpos_enu(antpos, lat, lon, alt):
     """
-    Compute the antenna positions in ENU coordinates from rotECEF.
+    Compute the antenna positions in ENU coordinates from ECEF.
 
     Args:
       antpos -- array of antenna positions. Should have shape (Nants, 3).
@@ -86,8 +86,8 @@ def get_antpos_enu(antpos, lat, lon, alt):
       enu -- array of antenna positions in ENU frame. Has shape (Nants, 3).
     """
     import pyuvdata.utils as uvutils
-    ecef = uvutils.ECEF_from_rotECEF(antpos, lon)
-    enu  = uvutils.ENU_from_ECEF(ecef, lat, lon, alt)
+    antpos = np.asarray(antpos)
+    enu  = uvutils.ENU_from_ECEF(antpos, lat, lon, alt)
     return enu
 
 def get_antpos_ecef(antpos, lon):
@@ -102,6 +102,7 @@ def get_antpos_ecef(antpos, lon):
       ecef -- array of antenna positions in ECEF frame. Has shape (Nants, 3)
     """
     import pyuvdata.utils as uvutils
+    antpos = np.asarray(antpos)
     ecef = uvutils.ECEF_from_rotECEF(antpos, lon)
     return ecef
 
@@ -168,10 +169,14 @@ def create_header(h5, config, use_cm=False, use_redis=False):
     if use_cm:
         cminfo = get_cm_info()
         # add the enu co-ords
-        lat = cminfo["cofa_lat"] * np.pi / 180.0
-        lon = cminfo["cofa_lon"] * np.pi / 180.0
-        alt = cminfo["cofa_alt"]
-        cminfo["antenna_positions_enu"] = get_antpos_enu(cminfo["antenna_positions"], lat, lon, alt)
+        # dict keys are bytes, not strings
+        lat = cminfo[b"cofa_lat"] * np.pi / 180.0
+        lon = cminfo[b"cofa_lon"] * np.pi / 180.0
+        alt = cminfo[b"cofa_alt"]
+        cofa_ecef = get_telescope_location_ecef(lat, lon, alt)
+        antenna_positions = np.asarray(cminfo[b"antenna_positions"])
+        antpos_ecef = antenna_positions + cofa_ecef
+        cminfo[b"antenna_positions_enu"] = get_antpos_enu(antpos_ecef, lat, lon, alt)
     else:
         cminfo = None
 
@@ -219,31 +224,27 @@ def create_header(h5, config, use_cm=False, use_redis=False):
     header.create_dataset("x_orientation", data=np.string_("NORTH"))
     if use_cm:
         # convert lat and lon from degrees -> radians
-        lat = cminfo['cofa_lat'] * np.pi / 180.0
-        lon = cminfo['cofa_lon'] * np.pi / 180.0
-        alt = cminfo['cofa_alt']
-        telescope_location_ecef = get_telescope_location_ecef(lat, lon, alt)
-        antpos_ecef = get_antpos_ecef(cminfo["antenna_positions"], lon)
-        header.create_dataset("altitude",    dtype="<f8", data=cminfo['cofa_alt'])
+        # dict keys are bytes, not strings
+        header.create_dataset("altitude",    dtype="<f8", data=cminfo[b'cofa_alt'])
         ant_pos = np.zeros([NANTS_DATA,3], dtype=np.float64)
         ant_pos_enu = np.zeros([NANTS_DATA,3], dtype=np.float64)
         ant_pos_uvw = np.zeros([NANTS,3], dtype=np.float64)
         ant_names = ["NONE"]*NANTS_DATA
         ant_nums = [-1]*NANTS_DATA
         # make uvw array
-        for n, i in enumerate(cminfo["antenna_numbers"]):
-            ant_pos_uvw[i] = cminfo["antenna_positions_enu"][n]
+        for n, i in enumerate(cminfo[b"antenna_numbers"]):
+            ant_pos_uvw[i] = cminfo[b"antenna_positions_enu"][n]
         for i,(a,b) in enumerate(baselines):
             uvw[i] = ant_pos_uvw[a] - ant_pos_uvw[b]
         # get antenna metadata only for connected antennas
         idx = 0
-        for n, ant in enumerate(cminfo["antenna_numbers"]):
+        for n, ant in enumerate(cminfo[b"antenna_numbers"]):
             if ant not in ant_1_array:
                 continue
-            ant_pos[idx]     = antpos_ecef[n] - telescope_location_ecef
-            ant_names[idx]   = np.string_(cminfo["antenna_names"][n])
-            ant_nums[idx]    = cminfo["antenna_numbers"][n]
-            ant_pos_enu[idx] = cminfo["antenna_positions_enu"][n]
+            ant_pos[idx]     = antenna_positions[n]
+            ant_names[idx]   = np.string_(cminfo[b"antenna_names"][n])
+            ant_nums[idx]    = cminfo[b"antenna_numbers"][n]
+            ant_pos_enu[idx] = cminfo[b"antenna_positions_enu"][n]
             idx += 1
         # make sure we have the number we're expecting
         if idx != NANTS_DATA:
@@ -252,8 +253,8 @@ def create_header(h5, config, use_cm=False, use_redis=False):
         header.create_dataset("antenna_numbers",   dtype="<i8", shape=(NANTS_DATA,), data=ant_nums)
         header.create_dataset("antenna_positions",   dtype="<f8", shape=(NANTS_DATA,3), data=ant_pos)
         header.create_dataset("antenna_positions_enu",   dtype="<f8", shape=(NANTS_DATA,3), data=ant_pos_enu)
-        header.create_dataset("latitude",    dtype="<f8", data=cminfo["cofa_lat"])
-        header.create_dataset("longitude",   dtype="<f8", data=cminfo["cofa_lon"])
+        header.create_dataset("latitude",    dtype="<f8", data=cminfo[b"cofa_lat"])
+        header.create_dataset("longitude",   dtype="<f8", data=cminfo[b"cofa_lon"])
     else:
         header.create_dataset("altitude",    dtype="<f8", data=0.0)
         header.create_dataset("antenna_names",     dtype="|S5", shape=(NANTS,), data=["NONE"]*NANTS)
@@ -276,19 +277,29 @@ def create_header(h5, config, use_cm=False, use_redis=False):
 def add_extra_keywords(obj, cminfo=None, fenginfo=None):
     extras = obj.create_group("extra_keywords")
     if cminfo is not None:
-        extras.create_dataset("cmver", data=np.string_(cminfo["cm_version"]))
+        extras.create_dataset("cmver", data=np.string_(cminfo[b"cm_version"]))
         # Convert any numpy arrays to lists so they can be JSON encoded
-        cminfo_copy = copy.deepcopy(cminfo)
-        for key in list(cminfo_copy.keys()):
-            if isinstance(cminfo_copy[key], np.ndarray):
-                cminfo_copy[key] = cminfo_copy[key].tolist()
+        cminfo_copy = {}
+        for key in list(cminfo.keys()):
+            str_key = key.decode("utf-8")
+            if isinstance(cminfo[key], np.ndarray):
+                cminfo_copy[str_key] = cminfo[key].tolist()
+            else:
+                cminfo_copy[str_key] = cminfo[key]
         extras.create_dataset("cminfo", data=np.string_(json.dumps(cminfo_copy)))
         del(cminfo_copy)
     else:
         extras.create_dataset("cmver", data=np.string_("generated-without-cminfo"))
         extras.create_dataset("cminfo", data=np.string_("generated-without-cminfo"))
     if fenginfo is not None:
-        extras.create_dataset("finfo", data=np.string_(json.dumps(fenginfo)))
+        fenginfo_copy = {}
+        for key in list(fenginfo.keys()):
+            str_key = key.decode("utf-8")
+            if isinstance(fenginfo[key], bytes):
+                fenginfo_copy[str_key] = fenginfo[key].decode("utf-8")
+            else:
+                fenginfo_copy[str_key] = fenginfo[key]
+        extras.create_dataset("finfo", data=np.string_(json.dumps(fenginfo_copy)))
     else:
         extras.create_dataset("finfo", data=np.string_("generated-without-redis"))
     #extras.create_dataset("st_type", data=np.string_("???"))

--- a/src/scripts/hera_make_hdf5_template_bda.py
+++ b/src/scripts/hera_make_hdf5_template_bda.py
@@ -234,8 +234,8 @@ def create_header(h5, config, use_cm=False, use_redis=False):
         # make uvw array
         for n, i in enumerate(cminfo["antenna_numbers"]):
             ant_pos_uvw[i] = cminfo["antenna_positions_enu"][n]
-        for i,(a,b) in enumerate(baselines):
-            uvw[i] = ant_pos_uvw[a] - ant_pos_uvw[b]
+        for i, (a, b) in enumerate(baselines):
+            uvw[i] = ant_pos_uvw[b] - ant_pos_uvw[a]
         # get antenna metadata only for connected antennas
         idx = 0
         for n, ant in enumerate(cminfo["antenna_numbers"]):

--- a/src/scripts/hera_make_hdf5_template_bda.py
+++ b/src/scripts/hera_make_hdf5_template_bda.py
@@ -9,7 +9,6 @@ import numpy as np
 import time
 import copy
 import redis
-import warnings
 from hera_corr_cm.handlers import add_default_log_handlers
 
 logger = add_default_log_handlers(logging.getLogger(__file__))
@@ -36,7 +35,7 @@ def get_corr_to_hera_map(r, nants_data=192, nants=352):
         chan = pol["n"]["channel"]  # runs 0-5
         snap_ant_chans = r.hget("corr:snap_ants", host)
         if snap_ant_chans is None:
-            warnings.warn("Couldn't find antenna indices for %s" % host)
+            logger.warning("Couldn't find antenna indices for %s" % host)
             continue
         corr_ant_number = json.loads(snap_ant_chans)[chan//2] #Indexes from 0-3 (ignores pol)
         print(corr_ant_number)
@@ -248,7 +247,7 @@ def create_header(h5, config, use_cm=False, use_redis=False):
             idx += 1
         # make sure we have the number we're expecting
         if idx != NANTS_DATA:
-            warnings.warn("Didn't get the right number of antenna positions. Expected {:d}, got {:d}".format(NANTS_DATA, idx))
+            logger.warning("Didn't get the right number of antenna positions. Expected {:d}, got {:d}".format(NANTS_DATA, idx))
         header.create_dataset("antenna_names",     dtype="|S5", shape=(NANTS_DATA,), data=ant_names)
         header.create_dataset("antenna_numbers",   dtype="<i8", shape=(NANTS_DATA,), data=ant_nums)
         header.create_dataset("antenna_positions",   dtype="<f8", shape=(NANTS_DATA,3), data=ant_pos)

--- a/src/scripts/tweak-perf-sn.sh
+++ b/src/scripts/tweak-perf-sn.sh
@@ -4,29 +4,29 @@
 for i in `ls /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`; do echo performance > $i; done
 
 # Set mtu
-ifconfig eth3 mtu 4500
+ifconfig eth4 mtu 4500
 
 # Turn on pause requests
-ethtool -A eth3 rx on
+ethtool -A eth4 rx on
 
 # Kernel buffer sizes
 sysctl net.core.rmem_max=83886080
 sysctl net.core.rmem_default=83886080
 
 # Kill packets before the IP stack
-iptables -t raw -A PREROUTING -i eth3 -p udp -j DROP
+iptables -t raw -A PREROUTING -i eth4 -p udp -j DROP
 
 # Set interrupt coalescing
-ethtool -C eth3 adaptive-rx off
-ethtool -C eth3 rx-frames 8
-ethtool -C eth3 rx-usecs 0
+ethtool -C eth4 adaptive-rx off
+ethtool -C eth4 rx-frames 8
+ethtool -C eth4 rx-usecs 0
 
 # Set ring sizes to max
-ethtool -G eth3 rx 8192
+ethtool -G eth4 rx 8192
 
 # Set Receiver Side Steering
-#ethtool -U eth3 flow-type udp4 src-ip 10.0.10.110 m 0.0.0.0 action 4 loc 1
-#ethtool -U eth3 flow-type udp4 src-ip 10.0.10.111 m 0.0.0.0 action 5 loc 2
-#ethtool -U eth3 flow-type udp4 src-ip 10.0.10.113 m 0.0.0.0 action 6 loc 3
-#ethtool -U eth3 flow-type udp4 src-ip 10.0.10.114 m 0.0.0.0 action 7 loc 4
-ethtool -U eth3 flow-type udp4 src-ip 10.80.40.1 m 255.255.255.255 action 1 loc 1
+#ethtool -U eth4 flow-type udp4 src-ip 10.0.10.110 m 0.0.0.0 action 4 loc 1
+#ethtool -U eth4 flow-type udp4 src-ip 10.0.10.111 m 0.0.0.0 action 5 loc 2
+#ethtool -U eth4 flow-type udp4 src-ip 10.0.10.113 m 0.0.0.0 action 6 loc 3
+#ethtool -U eth4 flow-type udp4 src-ip 10.0.10.114 m 0.0.0.0 action 7 loc 4
+ethtool -U eth4 flow-type udp4 src-ip 10.80.40.1 m 255.255.255.255 action 1 loc 1

--- a/src/tests/check_bda_uvh5_files.py
+++ b/src/tests/check_bda_uvh5_files.py
@@ -26,7 +26,7 @@ def get_corr_to_hera_map(nants_data=192, nants=352):
 
     r = redis.Redis('redishost')
     ant_to_snap = json.loads(r.hgetall("corr:map")['ant_to_snap'])
-    for ant, pol in ant_to_snap.iteritems():
+    for ant, pol in ant_to_snap.items():
         hera_ant_number = int(ant)
         host = pol["n"]["host"]
         chan = pol["n"]["channel"] # runs 0-5
@@ -73,9 +73,9 @@ parser.add_argument('--ramp', action='store_true', default=False,
                     help='Frequency ramp in test vectors')
 args = parser.parse_args()
 
-snap_pol_map = {u'e2':0,  u'n0':1,
-                u'e6':2,  u'n4':3,
-                u'e1':4, u'n8':5}
+snap_pol_map = {'e2':0,  'n0':1,
+                'e6':2,  'n4':3,
+                'e1':4, 'n8':5}
 
 # Compute expected baseline pairs from
 # the configuration file
@@ -121,7 +121,7 @@ fakeimag = -2j
 int_bin = {}
 
 if (args.paper_gpu) and not (args.ramp):
-   print 'Checking Data for {0:s} mode with {1:s} test vectors'.format('Hashpipe','Constant')
+   print('Checking Data for {0:s} mode with {1:s} test vectors'.format('Hashpipe','Constant'))
 
    # Constant
    for n in range(N_BDABUF_BINS):
@@ -151,7 +151,7 @@ if (args.paper_gpu) and not (args.ramp):
       assert(np.all(np.equal(uv.data_array[0, 0, :96, :], int_bin[3][:96, :])))
 
 if args.paper_gpu and args.ramp:
-   print 'Checking Data for {0:s} mode with {1:s} test vectors'.format('Hashpipe','Ramp')
+   print('Checking Data for {0:s} mode with {1:s} test vectors'.format('Hashpipe','Ramp'))
 
    # Ramp
    for n in range(N_BDABUF_BINS):
@@ -159,7 +159,7 @@ if args.paper_gpu and args.ramp:
       int_bin[n] = np.asarray((2**n)*(fakereal + fakeimag)*x, dtype=np.complex64)
 
 if args.fengine:
-   print 'Checking data for SNAPS in test vec mode' 
+   print('Checking data for SNAPS in test vec mode')
 
    factor = 4
 
@@ -172,12 +172,12 @@ if args.fengine:
 
    for a0, a1 in zip(uv.ant_1_array, uv.ant_2_array):
 
-       print("({0:2d},{1:2d}) \t".format(a0,a1)),
+       print(("({0:2d},{1:2d}) \t".format(a0,a1)), end=' ')
 
        try:
            data = uv.get_data(a1, a0)
        except (ValueError):
-           print 'Antenna pair (%d,%d) has no data!!!'%(a0,a1)
+           print('Antenna pair (%d,%d) has no data!!!'%(a0,a1))
            continue
   
 
@@ -188,10 +188,10 @@ if args.fengine:
        #tspec = tspec[:N_CHAN_TOTAL]
        tspec = np.sum(tspec.reshape(-1,4),axis=1)[:NCHANS]
 
-       print np.all(np.equal(tspec, data[0,:,0]/(factor*INTSPEC))), '\t',
+       print(np.all(np.equal(tspec, data[0,:,0]/(factor*INTSPEC))), '\t', end=' ')
 
        tspec = gen_tvg_pol(loca0 +1)*np.conj(gen_tvg_pol(loca1 +1))
        #tspec = tspec[:N_CHAN_TOTAL]
        tspec = np.sum(tspec.reshape(-1,4),axis=1)[:NCHANS]
 
-       print np.all(np.equal(tspec, data[0,:,1]/(factor*INTSPEC)))
+       print(np.all(np.equal(tspec, data[0,:,1]/(factor*INTSPEC))))

--- a/src/tests/check_fluff_output_databuf.py
+++ b/src/tests/check_fluff_output_databuf.py
@@ -42,5 +42,5 @@ for a in range(12):
             for t_fast in range(NTIME_FAST):
                 for cplx in range(NCPLX):
                     ok = ok and np.all(tvg[a, p, :, cplx] == x[t, :, a, p, cplx, t_fast])
-    print "Antenna %d: OK?:" % a, ok
+    print("Antenna %d: OK?:" % a, ok)
     #print tvg[a,0,:,:], x[0,:,a,0,:,0]

--- a/src/tests/check_gpu_output_databuf.py
+++ b/src/tests/check_gpu_output_databuf.py
@@ -16,6 +16,6 @@ with open(sys.argv[1], 'r') as fh:
 
 x = np.fromstring(raw, dtype=np.int32)
 
-print "All values equal to 0?:", np.all(x == 0)
-print "All values divisible by 2048?:", np.all((x % 2048) == 0)
-print "All values divisible by 262144?:", np.all((x % 262144) == 0)
+print("All values equal to 0?:", np.all(x == 0))
+print("All values divisible by 2048?:", np.all((x % 2048) == 0))
+print("All values divisible by 262144?:", np.all((x % 262144) == 0))

--- a/src/tests/check_net_output_databuf.py
+++ b/src/tests/check_net_output_databuf.py
@@ -28,5 +28,5 @@ for t in range(NTIMES/NTIME_PER_PKT):
                 tvg[t, a, :, t_pkt, p] = (np.arange(384) + 2*(a%3) + p) % 256
 
 for a in range(NANT_TOTAL):
-    print "Antenna %d: OK?:" % a,
-    print np.all(tvg[:,a,:,:,:] == x[:,a,:,:,:])
+    print("Antenna %d: OK?:" % a, end=' ')
+    print(np.all(tvg[:,a,:,:,:] == x[:,a,:,:,:]))

--- a/src/tests/check_xcorr_ordering_uvh5.py
+++ b/src/tests/check_xcorr_ordering_uvh5.py
@@ -62,7 +62,7 @@ for (a1,a2) in ant_pairs:
     except(KeyError):
         pass
 
-print 'Unique antennas', list(set([a[0] for a in ants]))
+print('Unique antennas', list(set([a[0] for a in ants])))
 
 if args.check_data:
     for a1,a2 in ants:
@@ -75,9 +75,9 @@ if args.check_data:
             tspec = gen_tvg_pol(snaploc_a1)*np.conj(gen_tvg_pol(snaploc_a2))
             tspec = np.sum(tspec.reshape(-1,4),axis=1)[:NCHANS]
 
-            print a1,a2, np.all(np.equal(tspec, uvd.get_data(a2,a1)[0,:,0]/INTSPEC))
+            print(a1,a2, np.all(np.equal(tspec, uvd.get_data(a2,a1)[0,:,0]/INTSPEC)))
 
             tspec = gen_tvg_pol(snaploc_a1+1)*np.conj(gen_tvg_pol(snaploc_a2+1))
             tspec = np.sum(tspec.reshape(-1,4),axis=1)[:NCHANS]
 
-            print a1,a2, np.all(np.equal(tspec, uvd.get_data(a2,a1)[0,:,1]/INTSPEC))
+            print(a1,a2, np.all(np.equal(tspec, uvd.get_data(a2,a1)[0,:,1]/INTSPEC)))


### PR DESCRIPTION
This PR makes the repo python3-only. This was accomplished by running `2to3`, and cleaning up remaining bits by hand. Most changes are around print statements and dictionary iteration. The only non-trivial change are around handling loggers for file creation inside the correlator, but these now use loggers from `hera_corr_cm`, which are python2/3 compatible.