### PR TITLE
Network issues

### DIFF
--- a/src/hera_bda_output_thread.c
+++ b/src/hera_bda_output_thread.c
@@ -66,12 +66,17 @@ typedef struct struct_pkt {
 //  100 megabit per second =  10 nanosecond per bit
 //   10 megabit per second = 100 nanosecond per bit
 
+// Set to 200 Mbps -- OK for two instances per node.
+// With 16 nodes, amounts to 6.4 Gbps of data
+
 // 8 * OUTPUT_BYTES_PER_PACKET == 1 Gbps
 // 4 * 8 * OUTPUT_BYTES_PER_PACKET == 0.25 Gbps
 
-// Set to 200 Mbps -- OK for two instances per node.
-// With 16 nodes, amounts to 6.4 Gbps of data
-#define PACKET_DELAY_NS (4 * 8 * OUTPUT_BYTES_PER_PACKET)
+// For full BDA, 350 ants, 384 chan per pipeline
+//#define PACKET_DELAY_NS (2 * 8 * OUTPUT_BYTES_PER_PACKET)
+
+// For no-BDA, 192 ants, 384 chan per pipeline -- 125 usec
+#define PACKET_DELAY_NS (125 * 1000)
 
 // Open and connect a UDP socket to the given host and port.  Note that port is
 // a string and can be a stringified integer (e.g. "7148") or a service name

--- a/src/hera_gpu_output_thread.c
+++ b/src/hera_gpu_output_thread.c
@@ -69,7 +69,18 @@ static XGPUInfo xgpu_info;
 
 // Set to 200 Mbps -- OK for two instances per node.
 // With 16 nodes, amounts to 6.4 Gbps of data
-#define PACKET_DELAY_NS (OUTPUT_BYTES_PER_PACKET>>2)
+
+// Original
+//#define PACKET_DELAY_NS (OUTPUT_BYTES_PER_PACKET>>2)
+
+// delivers packets for ~6 sec with 96 chan
+//#define PACKET_DELAY_NS (430 * 1000)
+
+// packets for ~6sec with 384 chan
+//#define PACKET_DELAY_NS (430 * 1000/4)
+
+// packet for ~7.5 sec with 384 chan
+#define PACKET_DELAY_NS (536 * 1000/4)
 
 // bytes_per_dump depends on xgpu_info.triLength
 static uint64_t bytes_per_dump = 0;

--- a/src/hera_pktsock_thread.c
+++ b/src/hera_pktsock_thread.c
@@ -497,9 +497,9 @@ static inline uint64_t process_packet(
     else if(pkt_mcnt_dist < 0 && pkt_mcnt_dist > -LATE_PKT_MCNT_THRESHOLD) {
 	// If not just after an mcnt reset, issue warning.
 	if(cur_mcnt >= binfo.mcnt_log_late) {
-	    hashpipe_warn("hera_pktsock_thread",
-		    "Ignoring late packet (%d mcnts late)",
-		    cur_mcnt - pkt_mcnt);
+	    hashpipe_warn("hera_pktsock_thread",  
+		    "Ignoring late packet (%d mcnts late, %d ant)",
+		    cur_mcnt - pkt_mcnt, pkt_header.ant);
 	}
 #ifdef LOG_MCNTS
 	late_packets_counted++;
@@ -512,8 +512,8 @@ static inline uint64_t process_packet(
 	// issue warning.
 	if(cur_mcnt != 0 && binfo.out_of_seq_cnt == 0) {
 	    hashpipe_warn("hera_pktsock_thread",
-		    "out of seq mcnt %012lx (expected: %012lx <= mcnt < %012x)",
-		    pkt_mcnt, cur_mcnt, cur_mcnt+3*N_TIME_PER_BLOCK*TIME_DEMUX);
+		    "out of seq mcnt %012lx from ant %d (expected mcnt: %012lx <= mcnt < %012x)",
+		    pkt_mcnt, pkt_header.ant, cur_mcnt, cur_mcnt+3*N_TIME_PER_BLOCK*TIME_DEMUX);
 	}
 
 	// Increment out-of-seq packet counter
@@ -539,8 +539,8 @@ static inline uint64_t process_packet(
 	    binfo.mcnt_log_late = binfo.mcnt_start + N_TIME_PER_BLOCK*TIME_DEMUX;
 	    binfo.block_i = block_for_mcnt(binfo.mcnt_start);
 	    hashpipe_warn("hera_pktsock_thread",
-		    "resetting to mcnt %012lx block %d based on packet mcnt %012lx",
-		    binfo.mcnt_start, block_for_mcnt(binfo.mcnt_start), pkt_mcnt);
+		    "resetting to mcnt %012lx block %d based on packet mcnt %012lx from ant %d",
+		    binfo.mcnt_start, block_for_mcnt(binfo.mcnt_start), pkt_mcnt, pkt_header.ant);
 	    // Reinitialize/recycle our two already acquired blocks with new
 	    // mcnt values.
 	    initialize_block(paper_input_databuf_p, binfo.mcnt_start);

--- a/src/paper_databuf.h
+++ b/src/paper_databuf.h
@@ -356,6 +356,7 @@ typedef struct hera_catcher_input_databuf {
 #define CHAN_PER_CATCHER_PKT   (OUTPUT_BYTES_PER_PACKET/(N_STOKES * 8L))                    // 128
 #define PACKETS_PER_BASELINE   (N_CHAN_TOTAL/CHAN_PER_CATCHER_PKT)                          //  48
 #define PACKETS_PER_BL_PER_X   (PACKETS_PER_BASELINE/N_XENGINES_PER_TIME)                   //   3
+#define PACKETS_PER_X          (BASELINES_PER_BLOCK*PACKETS_PER_BL_PER_X)                   // 768
 #define PACKETS_PER_BLOCK      (BASELINES_PER_BLOCK * TIME_DEMUX * PACKETS_PER_BASELINE)    // 1572864
 #define BYTES_PER_BLOCK        (PACKETS_PER_BLOCK * OUTPUT_BYTES_PER_PACKET)                // 6GB
 

--- a/src/paper_databuf.h
+++ b/src/paper_databuf.h
@@ -42,6 +42,7 @@
 #define N_PACKETS_PER_BLOCK_PER_F    (N_INPUTS_PER_PACKET * N_PACKETS_PER_BLOCK / N_FENGINES)
 // Number of X-engines per time slice. E.g. for HERA: 16.
 #define N_XENGINES_PER_TIME (N_CHAN_TOTAL / N_CHAN_PER_X)
+#define N_XENGINES          (N_XENGINES_PER_TIME*TIME_DEMUX)
 
 // Validate packet dimensions
 #if    N_BYTES_PER_PACKET != (N_TIME_PER_PACKET*N_CHAN_PER_PACKET*N_INPUTS_PER_PACKET)
@@ -309,6 +310,7 @@ typedef struct hera_bda_databuf{
 #define VIS_MATRIX_ENTRIES (N_CHAN_TOTAL/XENG_CHAN_SUM * (N_INPUTS * ((N_INPUTS>>1) + 1)))
 #define VIS_MATRIX_ENTRIES_PER_CHAN (N_INPUTS * ((N_INPUTS>>1) + 1))
 #define PACKETS_PER_VIS_MATRIX ((8L*TIME_DEMUX*VIS_MATRIX_ENTRIES) / OUTPUT_BYTES_PER_PACKET)
+#define PACKETS_PER_XENG_ID    (PACKETS_PER_VIS_MATRIX/N_XENGINES)
 #define N_STOKES                4
 
 typedef struct hera_catcher_input_header{
@@ -339,6 +341,9 @@ typedef struct hera_catcher_input_databuf {
   (2L*TIME_DEMUX*(VIS_MATRIX_ENTRIES_PER_CHAN * (N_CHAN_PER_X/XENG_CHAN_SUM)*(x)) + (TIME_DEMUX*((o)>>2)) + (2*N_STOKES*(t)))
 #define hera_catcher_input_databuf_by_bl_idx32(x, b) \
   (2L*TIME_DEMUX*(N_CHAN_PER_X/XENG_CHAN_SUM)*((VIS_MATRIX_ENTRIES_PER_CHAN * (x)) + (N_STOKES*(b))))
+
+// channels * vis_matrix * stokes * 4 bytes per re/imag
+#define MAX_HERA_CATCHER_IDX32 (((int64_t)N_XENGINES)*(N_CHAN_PER_X/XENG_CHAN_SUM)*VIS_MATRIX_ENTRIES_PER_CHAN*N_STOKES*4)
 
 
 /* 


### PR DESCRIPTION
Major changes in this branch:
- Increase throttle on the output thread of px-machines to prevent network issues, on both BDA and non-BDA threads.
- Elaborate print statements on all pkt-socket threads to show stats of packets. Late packets now show what SNAPs (in terms of antenna numbers) they are from and catcher shows rx stats per px machine.

Minor changes:
- An internal check on databuf size in catcher-net-thread now adapts to channel averaging.
- More macros in header file to handle these changes.