### PR TITLE
Fix nsamples array in data files

### DIFF
--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -778,8 +778,9 @@ static void *run(hashpipe_thread_args_t * args)
     hbool_t *flags     = (hbool_t *) malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
     float *nsamples = (float *)malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
 
-    memset(flags,    0, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
-    // memset(nsamples, 1, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
+    memset(flags, 0, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
+    // PLP: we want nsamples=1 for valid data, and memset Does The Wrong Thing for non-integer data.
+    // Someday we would like nsamples to also reflect the number of dropped packets.
     for (i=0; i<(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES); i++) {
       nsamples[i] = 1.0;
     }

--- a/src/hera_catcher_disk_thread_bda.c
+++ b/src/hera_catcher_disk_thread_bda.c
@@ -779,7 +779,10 @@ static void *run(hashpipe_thread_args_t * args)
     float *nsamples = (float *)malloc(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
 
     memset(flags,    0, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(hbool_t));
-    memset(nsamples, 1, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
+    // memset(nsamples, 1, N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES * sizeof(float));
+    for (i=0; i<(N_BL_PER_WRITE * N_CHAN_PROCESSED * N_STOKES); i++) {
+      nsamples[i] = 1.0;
+    }
 
     // Define memory space of a block
     hsize_t dims[N_DATA_DIMS] = {N_BL_PER_WRITE, 1, N_CHAN_PROCESSED, N_STOKES};

--- a/src/scripts/tweak-perf.sh
+++ b/src/scripts/tweak-perf.sh
@@ -14,6 +14,11 @@ ethtool -A eth5 rx on
 # Kernel buffer sizes
 sysctl net.core.rmem_max=8388608
 sysctl net.core.rmem_default=8388608
+#sysctl net.core.rmem_max=838860800
+#sysctl net.core.rmem_default=838860800
+#sysctl net.core.netdev_max_backlog=250000
+##sysctl net.core.netdev_max_backlog=1000
+#sysctl net.core.netdev_budget=300
 
 # Kill packets before the IP stack
 iptables -t raw -A PREROUTING -i eth3 -p udp -j DROP


### PR DESCRIPTION
This PR is a trivial fix to the initialization of the nsamples array in UVH5 files. Ideally we would like this array to reflect dropped packets from the X-engines, but that is a project for another day.