### PR TITLE
Allow for larger antenna numbers in the autocorr thread

### DIFF
--- a/src/hera_catcher_autocorr_thread.c
+++ b/src/hera_catcher_autocorr_thread.c
@@ -91,7 +91,7 @@ static void *run(hashpipe_thread_args_t * args)
     // Write autocorrs to redis
     if(use_redis){
       printf("Entered loop\n");
-      for (ant=0; ant<N_ANTS; ant++) {
+      for (ant=0; ant<N_ANTS_TOTAL; ant++) {
          if (db_in->block[blkin].header.ant[ant] == 1){
             for (chan=0; chan<N_CHAN_TOTAL; chan++){
               offset = hera_catcher_autocorr_databuf_idx32(ant);


### PR DESCRIPTION
Change from N_ANTS to N_ANTS_TOTAL to allow for larger antenna numbers. This is similar to what is done in `hera_catcher_disk_thread.c` and it appears that the autocorr block should be big enough for this because of the following line in `paper_databuf.h`:
```
#define BYTES_AUTOCORR_BLK  (N_CHAN_TOTAL * N_ANTS_TOTAL * N_STOKES * 8L)
```

However, this is way outside my comfort zone so someone with real knowledge needs to check that this is ok.